### PR TITLE
Fix versioncheck.h include on case-sensitive file systems.

### DIFF
--- a/src/versioncheck/versioncheck.cpp
+++ b/src/versioncheck/versioncheck.cpp
@@ -15,7 +15,7 @@
  *
  */
 
-#include "VersionCheck.h"
+#include "versioncheck.h"
 #include <QSettings>
 #include <QRandomGenerator>
 #include <QGuiApplication>


### PR DESCRIPTION
Linux filesystems are case-sensitive, so the include has to be renamed in order to build on them.